### PR TITLE
add missing golang dependency

### DIFF
--- a/Dockerfiles/Ubuntu/2204/Dockerfile
+++ b/Dockerfiles/Ubuntu/2204/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
   && apt-get update \
   && apt-get install --yes --no-install-recommends \
       git \
+      golang \
       make \
       nodejs \
       openssh-server \


### PR DESCRIPTION
Found this dependency missing when attempt to run the gh workflows locally in other repos.